### PR TITLE
add ActiveState branding

### DIFF
--- a/Doc/copyright.rst
+++ b/Doc/copyright.rst
@@ -13,6 +13,8 @@ reserved.
 
 Copyright © 1991-1995 Stichting Mathematisch Centrum. All rights reserved.
 
+Binary build provided by ActiveState http://www.ActiveState.com
+
 -------
 
 See :ref:`history-and-license` for complete license and permissions information.

--- a/Lib/asyncio/__main__.py
+++ b/Lib/asyncio/__main__.py
@@ -71,6 +71,7 @@ class REPLThread(threading.Thread):
         try:
             banner = (
                 f'asyncio REPL {sys.version} on {sys.platform}\n'
+                f'Binary build provided by ActiveState http://www.ActiveState.com\n'
                 f'Use "await" directly instead of "asyncio.run()".\n'
                 f'Type "help", "copyright", "credits" or "license" '
                 f'for more information.\n'

--- a/Lib/code.py
+++ b/Lib/code.py
@@ -211,7 +211,7 @@ class InteractiveConsole(InteractiveInterpreter):
             sys.ps2 = "... "
         cprt = 'Type "help", "copyright", "credits" or "license" for more information.'
         if banner is None:
-            self.write("Python %s on %s\n%s\n(%s)\n" %
+            self.write("Python %s on %s\nBinary build provided by ActiveState http://www.ActiveState.com\n%s\n(%s)\n" %
                        (sys.version, sys.platform, cprt,
                         self.__class__.__name__))
         elif banner:

--- a/Lib/idlelib/pyshell.py
+++ b/Lib/idlelib/pyshell.py
@@ -1057,7 +1057,7 @@ class PyShell(OutputWindow):
                     "for details.\n\n")
             sys.displayhook = rpc.displayhook
 
-        self.write("Python %s on %s\n%s\n%s" %
+        self.write("Python %s on %s\nBinary build provided by ActiveState http://www.ActiveState.com\n%s\n%s" %
                    (sys.version, sys.platform, self.COPYRIGHT, nosub))
         self.text.focus_force()
         self.showprompt()

--- a/Lib/site.py
+++ b/Lib/site.py
@@ -395,7 +395,8 @@ def setcopyright():
     else:
         builtins.credits = _sitebuiltins._Printer("credits", """\
     Thanks to CWI, CNRI, BeOpen.com, Zope Corporation and a cast of thousands
-    for supporting Python development.  See www.python.org for more information.""")
+    for supporting Python development.  See www.python.org for more information.
+    Binary build provided by ActiveState http://www.ActiveState.com""")
     files, dirs = [], []
     # Not all modules are required to have a __file__ attribute.  See
     # PEP 420 for more details.

--- a/Modules/main.c
+++ b/Modules/main.c
@@ -192,7 +192,8 @@ pymain_header(const PyConfig *config)
         return;
     }
 
-    fprintf(stderr, "Python %s on %s\n", Py_GetVersion(), Py_GetPlatform());
+    fprintf(stderr, "Python %s on %s\nBinary build provided by ActiveState http://www.ActiveState.com\n",
+        Py_GetVersion(), Py_GetPlatform());
     if (config->site_import) {
         fprintf(stderr, "%s\n", COPYRIGHT);
     }

--- a/PC/python_ver_rc.h
+++ b/PC/python_ver_rc.h
@@ -5,7 +5,7 @@
 #include "winver.h"
 
 #define PYTHON_COMPANY   "Python Software Foundation"
-#define PYTHON_COPYRIGHT "Copyright \xA9 2001-2016 Python Software Foundation. Copyright \xA9 2000 BeOpen.com. Copyright \xA9 1995-2001 CNRI. Copyright \xA9 1991-1995 SMC."
+#define PYTHON_COPYRIGHT "Copyright \xA9 2001-2016 Python Software Foundation. Copyright \xA9 2000 BeOpen.com. Copyright \xA9 1995-2001 CNRI. Copyright \xA9 1991-1995 SMC. \xA9 Binary build provided by ActiveState http://www.ActiveState.com"
 
 #define MS_WINDOWS
 #include "modsupport.h"

--- a/Python/frozenmain.c
+++ b/Python/frozenmain.c
@@ -92,7 +92,7 @@ Py_FrozenMain(int argc, char **argv)
 #endif
 
     if (Py_VerboseFlag)
-        fprintf(stderr, "Python %s\n%s\n",
+        fprintf(stderr, "Python %s\nBinary build provided by ActiveState http://www.ActiveState.com\n%s\n",
             Py_GetVersion(), Py_GetCopyright());
 
     PySys_SetArgv(argc, argv_copy);

--- a/Python/getcopyright.c
+++ b/Python/getcopyright.c
@@ -14,7 +14,9 @@ Copyright (c) 1995-2001 Corporation for National Research Initiatives.\n\
 All Rights Reserved.\n\
 \n\
 Copyright (c) 1991-1995 Stichting Mathematisch Centrum, Amsterdam.\n\
-All Rights Reserved.";
+All Rights Reserved.\n\
+\n\
+Binary build provided by ActiveState http://www.ActiveState.com";
 
 const char *
 Py_GetCopyright(void)

--- a/README.rst
+++ b/README.rst
@@ -259,6 +259,8 @@ rights reserved.
 
 Copyright (c) 1991-1995 Stichting Mathematisch Centrum.  All rights reserved.
 
+Binary build provided by ActiveState http://www.ActiveState.com
+
 See the file "LICENSE" for information on the history of this software, terms &
 conditions for usage, and a DISCLAIMER OF ALL WARRANTIES.
 


### PR DESCRIPTION
This is the affect of these changes in the python REPL:
```bash
❯ ./python.exe
Python 3.10.0a0 (heads/branding-dirty:5241e189e7, Mar  4 2021, 15:16:23)
[Clang 12.0.0 (clang-1200.0.32.29)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
15:19:23.73 $ copyright
Copyright (c) 2001-2020 Python Software Foundation.
All Rights Reserved.

Copyright (c) 2000 BeOpen.com.
All Rights Reserved.

Copyright (c) 1995-2001 Corporation for National Research Initiatives.
All Rights Reserved.

Copyright (c) 1991-1995 Stichting Mathematisch Centrum, Amsterdam.
All Rights Reserved.

Binary build provided by ActiveState http://www.ActiveState.com
15:19:28.54 $ credits
    Thanks to CWI, CNRI, BeOpen.com, Zope Corporation and a cast of thousands
    for supporting Python development.  See www.python.org for more information.
    Binary build provided by ActiveState http://www.ActiveState.com
15:19:34.01 $ license
Type license() to see the full license text
15:19:44.99 $ license()
A. HISTORY OF THE SOFTWARE
==========================

Python was created in the early 1990s by Guido van Rossum at Stichting
Mathematisch Centrum (CWI, see http://www.cwi.nl) in the Netherlands
as a successor of a language called ABC.  Guido remains Python's
principal author, although it includes many contributions from others.

In 1995, Guido continued his work on Python at the Corporation for
National Research Initiatives (CNRI, see http://www.cnri.reston.va.us)
in Reston, Virginia where he released several versions of the
software.

In May 2000, Guido and the Python core development team moved to
BeOpen.com to form the BeOpen PythonLabs team.  In October of the same
year, the PythonLabs team moved to Digital Creations, which became
Zope Corporation.  In 2001, the Python Software Foundation (PSF, see
https://www.python.org/psf/) was formed, a non-profit organization
created specifically to own Python-related Intellectual Property.
Zope Corporation was a sponsoring member of the PSF.

All Python releases are Open Source (see http://www.opensource.org for
the Open Source Definition).  Historically, most, but not all, Python
Hit Return for more, or q (and Return) to quit: q
15:20:51.33 $ help()

Welcome to Python 3.10's help utility!

If this is your first time using Python, you should definitely check out
the tutorial on the Internet at https://docs.python.org/3.10/tutorial/.

Enter the name of any module, keyword, or topic to get help on writing
Python programs and using Python modules.  To quit this help utility and
return to the interpreter, just type "quit".

To get a list of available modules, keywords, symbols, or topics, type
"modules", "keywords", "symbols", or "topics".  Each module also comes
with a one-line summary of what it does; to list the modules whose name
or summary contain a given string such as "spam", type "modules spam".

help> q

You are now leaving help and returning to the Python interpreter.
If you want to ask for help on a particular object directly from the
interpreter, you can type "help(object)".  Executing "help('string')"
has the same effect as typing a particular string at the help> prompt.
15:20:55.07 $ ^D
```