### PR TITLE
Add copyrights to cpython continued support work

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -59,6 +59,54 @@ direction to make these releases possible.
 B. TERMS AND CONDITIONS FOR ACCESSING OR OTHERWISE USING PYTHON
 ===============================================================
 
+ACTIVESTATE LICENSE AGREEMENT FOR PYTHON 2.7 GREATER THAN 2.7.18
+----------------------------------------------------------------
+
+1. This LICENSE AGREEMENT is between ActiveState Software Inc. ("ActiveState"),
+and the Individual or Organization ("Licensee") accessing and otherwise using
+this software ("Python") in source or binary form and its associated
+documentation.
+
+2. Subject to the terms and conditions of this License Agreement, ActiveState
+hereby grants Licensee a nonexclusive, royalty-free, world-wide license to
+reproduce, analyze, test, perform and/or display publicly, prepare derivative
+works, distribute, and otherwise use Python alone or in any derivative version,
+provided, however, that ActiveState's License Agreement and ActiveState's
+notice of copyright, i.e., "Copyright (c) 2020, 2021 ActiveState Software Inc.;
+All Rights Reserved" are retained in Python alone or in any derivative version
+prepared by Licensee.
+
+3. In the event Licensee prepares a derivative work that is based on
+or incorporates Python or any part thereof, and wants to make
+the derivative work available to others as provided herein, then
+Licensee hereby agrees to include in any such work a brief summary of
+the changes made to Python.
+
+4. ActiveState is making Python available to Licensee on an "AS IS"
+basis.  ActiveState MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, ActiveState MAKES NO AND
+DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF PYTHON WILL NOT
+INFRINGE ANY THIRD PARTY RIGHTS.
+
+5. ActiveState SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF PYTHON
+FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING PYTHON,
+OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+6. This License Agreement will automatically terminate upon a material
+breach of its terms and conditions.
+
+7. Nothing in this License Agreement shall be deemed to create any
+relationship of agency, partnership, or joint venture between ActiveState and
+Licensee.  This License Agreement does not grant permission to use ActiveState
+trademarks or trade name in a trademark sense to endorse or promote
+products or services of Licensee, or any third party.
+
+8. By copying, installing or otherwise using Python, Licensee
+agrees to be bound by the terms and conditions of this License
+Agreement.
+
 PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
 --------------------------------------------
 

--- a/Lib/cgi.py
+++ b/Lib/cgi.py
@@ -1,5 +1,9 @@
 #! /usr/local/bin/python
 
+# Copyright (C) 2021 ActiveState Software Inc.
+# cgi is licensed under the PSFLv2 License.
+# See the file LICENSE for details.
+
 # NOTE: the above "/usr/local/bin/python" is NOT a mistake.  It is
 # intentionally NOT "/usr/bin/env python".  On many systems
 # (e.g. Solaris), /usr/local/bin is not in $PATH as passed to CGI

--- a/Lib/ctypes/test/test_parameters.py
+++ b/Lib/ctypes/test/test_parameters.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2021 ActiveState Software Inc.
+# test_parameters is licensed under the PSFLv2 License.
+# See the file LICENSE for details.
+
 import unittest, sys
 from ctypes.test import need_symbol
 import test.support

--- a/Lib/httplib.py
+++ b/Lib/httplib.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 ActiveState Software Inc.
+# httplib is licensed under the PSFLv2 License.
+# See the file LICENSE for details.
+
 r"""HTTP/1.1 client library
 
 <intro stuff goes here>

--- a/Lib/test/multibytecodec_support.py
+++ b/Lib/test/multibytecodec_support.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 ActiveState Software Inc.
+# multibytecodec_support is licensed under the PSFLv2 License.
+# See the file LICENSE for details.
+
 # multibytecodec_support.py
 #   Common Unittest Routines for CJK codecs
 #

--- a/Lib/test/test_cgi.py
+++ b/Lib/test/test_cgi.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2021 ActiveState Software Inc.
+# test_cgi is licensed under the PSFLv2 License.
+# See the file LICENSE for details.
+
 from io import BytesIO
 from test.test_support import run_unittest, check_warnings
 import cgi

--- a/Lib/test/test_tarfile.py
+++ b/Lib/test/test_tarfile.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 ActiveState Software Inc.
+# test_tarfile is licensed under the PSFLv2 License.
+# See the file LICENSE for details.
+
 import sys
 import os
 import shutil

--- a/Lib/test/test_urlparse.py
+++ b/Lib/test/test_urlparse.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2021 ActiveState Software Inc.
+# test_urlparse is licensed under the PSFLv2 License.
+# See the file LICENSE for details.
+
 from test import test_support
 import sys
 import unicodedata

--- a/Lib/urllib2.py
+++ b/Lib/urllib2.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2020 ActiveState Software Inc.
+# urllib2 is licensed under the PSFLv2 License.
+# See the file LICENSE for details.
+
 """An extensible library for opening URLs using a variety of protocols
 
 The simplest way to use this module is to call the urlopen function,

--- a/Lib/urlparse.py
+++ b/Lib/urlparse.py
@@ -1,3 +1,7 @@
+# Copyright (C) 2021 ActiveState Software Inc.
+# cgi is licensed under the PSFLv2 License.
+# See the file LICENSE for details.
+
 """Parse (absolute and relative) URLs.
 
 urlparse module is based upon the following RFC specifications.

--- a/Misc/NEWS.d/2.7.18.1.rst
+++ b/Misc/NEWS.d/2.7.18.1.rst
@@ -1,0 +1,7 @@
+.. bpo: 0
+.. date: 2020-09-29
+.. nonce: caft@D
+.. release date: 2020-09-29
+.. section: Library
+
+Address CVE-2020-8492 in urllib2

--- a/Misc/NEWS.d/2.7.18.2.rst
+++ b/Misc/NEWS.d/2.7.18.2.rst
@@ -1,0 +1,21 @@
+.. bpo: 0
+.. date: 2020-11-13
+.. nonce: TRAK.h
+.. release date: 2020-11-13
+.. section: Library
+
+Address CVE-2020-27619 in multibytecodec tests
+
+.. bpo: 0
+.. date: 2020-11-12
+.. nonce: GEH1va
+.. section: Library
+
+Address CVE-2020-26116 in httplib
+
+.. bpo: 0
+.. date: 2020-11-03
+.. nonce: TWAB9g
+.. section: Library
+
+Address CVE-2019-20907 in tarfile

--- a/Misc/NEWS.d/2.7.18.3.rst
+++ b/Misc/NEWS.d/2.7.18.3.rst
@@ -1,0 +1,7 @@
+.. bpo: 0
+.. date: 2021-02-09
+.. nonce: yic.vi
+.. release date: 2021-02-09
+.. section: Library
+
+Address CVE-2021-3177 in ctypes

--- a/Misc/NEWS.d/2.7.18.4.rst
+++ b/Misc/NEWS.d/2.7.18.4.rst
@@ -1,0 +1,7 @@
+.. bpo: 0
+.. date: 2021-04-05
+.. nonce: dip*SU
+.. release date: 2020-04-05
+.. section: Library
+
+Address CVE-2020-8492 in urlparse

--- a/Modules/_ctypes/callproc.c
+++ b/Modules/_ctypes/callproc.c
@@ -1,3 +1,9 @@
+/*
+ * Copyright (C) 2021 ActiveState Software Inc.
+ * callproc is licensed under the PSFLv2 License.
+ * See the file LICENSE for details.
+ */
+
 /*****************************************************************
   This file contains remnant Python 2.3 compatibility code that is no longer
   strictly required.


### PR DESCRIPTION
We should be taking credit for the work put into cpython2.7 to continue fixing CVEs. We have so far released 3 micro versions and are about to release a fourth, with no new copyrights or credit, except in the git commits.

# AC

* source files altered as part of python2.7 maintenance should additionally have an ActiveState copyright banner
    * make sure to not apply copyright for patches from cpython3.X that apply 1:1

# Open Questions

* Which license type should this be distributed under?
    * I think it will have to be PSFL in order to keep the platform promises
* What should this text actually be?
* What do we do when the upstream fix is enough on its own to fix 2.7?
    * add copyright for that author?
    * I believe by publishing it to python/cpython the owner allows the work to be relicensed under python already.