### PR TITLE
BE-2201-python2 alt builders

### DIFF
--- a/Include/patchlevel.h
+++ b/Include/patchlevel.h
@@ -27,7 +27,7 @@
 #define PY_RELEASE_SERIAL	0
 
 /* Version as a string */
-#define PY_VERSION      	"2.7.18.6"
+#define PY_VERSION      	"2.7.18.7"
 /*--end constants--*/
 
 /* Subversion Revision number of this file (not of the repository). Empty

--- a/Misc/NEWS.d/2.7.18.7.rst
+++ b/Misc/NEWS.d/2.7.18.7.rst
@@ -1,0 +1,7 @@
+.. bpo: 0
+.. date: 2023-06-27
+.. nonce: uUhs7b
+.. release date: 2023-06-27
+.. section: Core and Builtins
+
+Use alt-builders builder to build Python


### PR DESCRIPTION
Python >= 2.7.18.7 will now be built with alt-builder.