### PR TITLE
Always define SUPPRESS_IPH macros

### DIFF
--- a/Include/pyport.h
+++ b/Include/pyport.h
@@ -947,7 +947,6 @@ typedef struct fd_set {
 #define Py_ULL(x) Py_LL(x##U)
 #endif
 
-#ifdef Py_BUILD_CORE 
 /*
  * Macros to protect CRT calls against instant termination when passed an
  * invalid parameter (issue23524).
@@ -965,6 +964,5 @@ extern _invalid_parameter_handler _Py_silent_invalid_parameter_handler;
 #define _Py_END_SUPPRESS_IPH
 
 #endif /* _MSC_VER >= 1900 */
-#endif /* Py_BUILD_CORE */
 
 #endif /* Py_PYPORT_H */


### PR DESCRIPTION
Before this fix:
```
$ ./python.exe
   1 Python 2.7.18.7 (heads/jeremyp/io:4e9e681155, Jul  7 2023, 18:48:04)
   2 [GCC 12.2.0] on linux2
   3 Type "help", "copyright", "credits" or "license" for more information.
   4 >>> import io
   5 Traceback (most recent call last):
   6   File "<stdin>", line 1, in <module>
   7   File "/cpython/Lib/io.py", line 51, in <module>
   8     import _io
   9 ImportError: No module named _io
  10 >>>
```
because `io` is a module, not core. Import on Linux now works as expected.




(thanks @leahneukirchen!!)