### PR TITLE
BE-3131 Fix regression in test_signal

### DIFF
--- a/Modules/signalmodule.c
+++ b/Modules/signalmodule.c
@@ -417,6 +417,12 @@ signal_set_wakeup_fd(PyObject *self, PyObject *args)
         return NULL;
     }
 #endif
+
+    if (fd != -1 && fstat(fd, &buf) != 0) {
+        PyErr_SetString(PyExc_ValueError, "invalid fd");
+        return NULL;
+    }
+
     old_fd = wakeup_fd;
     wakeup_fd = fd;
     return PyLong_FromLong(old_fd);


### PR DESCRIPTION
Fix for code removed by https://github.com/ActiveState/cpython/commit/e361063c32483cea3a90af5bac7ca68be3569b82.
An update was also made to the if statement.

Failing test:

======================================================================
FAIL: test_invalid_fd (__main__.WakeupFDTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/as-build/.cache/activestate/46e56921/usr/lib/python2.7/test/test_signal.py", line 239, in test_invalid_fd
    self.assertRaises(ValueError, signal.set_wakeup_fd, fd)
AssertionError: ValueError not raised