### PR TITLE
bpo-42051: Reject XML entity declarations in plist files (#22760) (GC-22801)

### DIFF
--- a/Lib/plistlib.py
+++ b/Lib/plistlib.py
@@ -403,8 +403,15 @@ class PlistParser:
         parser.StartElementHandler = self.handleBeginElement
         parser.EndElementHandler = self.handleEndElement
         parser.CharacterDataHandler = self.handleData
+        parser.EntityDeclHandler = self.handle_entity_decl
         parser.ParseFile(fileobj)
         return self.root
+
+    def handle_entity_decl(self, entity_name, is_parameter_entity, value, base, system_id, public_id, notation_name):
+        # Reject plist files with entity declarations to avoid XML vulnerabilies in expat.
+        # Regular plist files don't contain those declerations, and Apple's plutil tool does not
+        # accept them either.
+        raise InvalidFileException("XML entity declarations are not supported in plist files")
 
     def handleBeginElement(self, element, attrs):
         self.data = []

--- a/Lib/test/test_plistlib.py
+++ b/Lib/test/test_plistlib.py
@@ -86,6 +86,19 @@ TESTDATA = """<?xml version="1.0" encoding="UTF-8"?>
 </plist>
 """.replace(" " * 8, "\t")  # Apple as well as plistlib.py output hard tabs
 
+XML_PLIST_WITH_ENTITY=b'''\
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd" [
+   <!ENTITY entity "replacement text">
+  ]>
+<plist version="1.0">
+  <dict>
+    <key>A</key>
+    <string>&entity;</string>
+  </dict>
+</plist>
+'''
+
 
 class TestPlistlib(unittest.TestCase):
 
@@ -195,6 +208,10 @@ class TestPlistlib(unittest.TestCase):
         self.assertEqual(test1, result1)
         self.assertEqual(test2, result2)
 
+    def test_xml_plist_with_entity_decl(self):
+        with self.assertRaisesRegex(plistlib.InvalidFileException,
+                                    "XML entity declarations are not supported"):
+            plistlib.loads(XML_PLIST_WITH_ENTITY, fmt=plistlib.FMT_XML)
 
 def test_main():
     test_support.run_unittest(TestPlistlib)

--- a/Misc/NEWS.d/2.7.18.8.rst
+++ b/Misc/NEWS.d/2.7.18.8.rst
@@ -44,3 +44,13 @@ A flaw was found in Python, specifically within the urllib.parse module. This mo
 CVE-2021-4189
 
 A flaw was found in Python, specifically in the FTP (File Transfer Protocol) client library in PASV (passive) mode. The issue is how the FTP client trusts the host from the PASV response by default. This flaw allows an attacker to set up a malicious FTP server that can trick FTP clients into connecting back to a given IP address and port. This vulnerability could lead to FTP client scanning ports, which otherwise would not have been possible.
+
+.. bpo: 42051
+.. date: 2024-03-12
+.. nonce:
+.. release date: 2024-03-12
+.. section: Core and Builtins
+
+CVE-2022-48565
+
+An XML External Entity (XXE) issue was discovered in Python through 3.9.1. The plistlib module no longer accepts entity declarations in XML plist files to avoid XML vulnerabilities.

--- a/Misc/NEWS.d/next/Security/2020-10-19-10-56-27.bpo-42051.EU_B7u.rst
+++ b/Misc/NEWS.d/next/Security/2020-10-19-10-56-27.bpo-42051.EU_B7u.rst
@@ -1,0 +1,3 @@
+The :mod: module no longer accepts entity declarations in XML
+plist files to avoid XML vulnerabilities. This should not affect users as
+entity declarations are not used in regular plist files.


### PR DESCRIPTION
Cherry-pick for CVE-2022-48565
An XML External Entity (XXE) issue was discovered in Python through 3.9.1. The plistlib module no longer accepts entity declarations in XML plist files to avoid XML vulnerabilities.