### PR TITLE
CVE-2022-48566 Cherry-pick 8bef9ebb1b88cfa4b2a38b93fe4ea22015d8254a

### DIFF
--- a/Misc/NEWS.d/next/Security/2020-05-28-06-06-47.bpo-40791.QGZClX.rst
+++ b/Misc/NEWS.d/next/Security/2020-05-28-06-06-47.bpo-40791.QGZClX.rst
@@ -1,0 +1,1 @@
+Add ``volatile`` to the accumulator variable in ``hmac.compare_digest``, making constant-time-defeating optimizations less likely.

--- a/Modules/operator.c
+++ b/Modules/operator.c
@@ -259,7 +259,7 @@ _tscmp(const unsigned char *a, const unsigned char *b,
     volatile const unsigned char *left;
     volatile const unsigned char *right;
     Py_ssize_t i;
-    unsigned char result;
+    volatile unsigned char result;
 
     /* loop count depends on length of b */
     length = len_b;


### PR DESCRIPTION
bpo-40791: Make compare_digest more constant-time. (GH-23438) (GH-23767)

The existing volatile `left`/`right` pointers guarantee that the reads will all occur, but does not guarantee that they will be _used_. So a compiler can still short-circuit the loop, saving e.g. the overhead of doing the xors and especially the overhead of the data dependency between `result` and the reads. That would change performance depending on where the first unequal byte occurs. This change removes that optimization.

(This is change GH-1 from https://bugs.python.org/issue40791 .)
(cherry picked from commit 31729366e2bc09632e78f3896dbce0ae64914f28)

(cherry picked from commit 8bef9ebb1b88cfa4b2a38b93fe4ea22015d8254a)