### PR TITLE
Refactor CVE-2023-27043 patch to support Unicode characters

### DIFF
--- a/Lib/email/test/test_email.py
+++ b/Lib/email/test/test_email.py
@@ -2425,6 +2425,22 @@ Foo
         eq(Utils.getaddresses(
            ['foo: ;', '"Jason R. Mastaler" <jason@dom.ain>']),
            [('', ''), ('Jason R. Mastaler', 'jason@dom.ain')])
+        
+    def test_getaddresses_nasty_unicode(self):
+        """Test parseaddr with unicode strings in Python 2"""
+
+        test_cases = [
+            u'user@example.com',
+            u'Test User <user@example.com>',
+            u'"Test User" <user@example.com>',
+        ]
+        
+        for addr in test_cases:
+            result = Utils.parseaddr(addr, strict=True)
+            self.assertNotEqual(result, ('', ''))
+            
+            result_non_strict = Utils.parseaddr(addr, strict=False)
+            self.assertEqual(result, result_non_strict)
 
     def test_getaddresses_embedded_comment(self):
         """Test proper handling of a nested comment"""

--- a/Lib/email/test/test_email_renamed.py
+++ b/Lib/email/test/test_email_renamed.py
@@ -2286,6 +2286,22 @@ Foo
         eq(utils.getaddresses(
            ['foo: ;', '"Jason R. Mastaler" <jason@dom.ain>']),
            [('', ''), ('Jason R. Mastaler', 'jason@dom.ain')])
+        
+    def test_getaddresses_nasty_unicode(self):
+        """Test parseaddr with unicode strings in Python 2"""
+
+        test_cases = [
+            u'user@example.com',
+            u'Test User <user@example.com>',
+            u'"Test User" <user@example.com>',
+        ]
+        
+        for addr in test_cases:
+            result = utils.parseaddr(addr, strict=True)
+            self.assertNotEqual(result, ('', ''))
+            
+            result_non_strict = utils.parseaddr(addr, strict=False)
+            self.assertEqual(result, result_non_strict)
 
     def test_getaddresses_embedded_comment(self):
         """Test proper handling of a nested comment"""

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -340,7 +340,7 @@ def parseaddr(addr, strict=True):
         addr = addr[0]
 
     # FIX: Support both str and unicode in Python 2
-    if not isinstance(addr, (str, unicode)):  # Python 2 compatible
+    if not isinstance(addr, (str, unicode)):
         return ('', '')
 
     # Convert unicode to str for consistent processing

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -339,8 +339,13 @@ def parseaddr(addr, strict=True):
     if isinstance(addr, list):
         addr = addr[0]
 
-    if not isinstance(addr, str):
+    # FIX: Support both str and unicode in Python 2
+    if not isinstance(addr, (str, unicode)):  # Python 2 compatible
         return ('', '')
+
+    # Convert unicode to str for consistent processing
+    if isinstance(addr, unicode):
+        addr = addr.encode('utf-8')
 
     addr = _pre_parse_validation([addr])[0]
     addrs = _post_parse_validation(_AddressList(addr).addresslist)


### PR DESCRIPTION
The patch https://github.com/ActiveState/cpython/commit/8cc4686084dbba0e5fba49e9d3a5048a1cb7b580 for CVE-2023-27043 only supported strings, not unicode characters. 

This new patch supports both cases.

```
root@8e92ba5c0e38:/# python -m test test_email
Run tests sequentially
0:00:00 load avg: 1.04 [1/1] test_email

== Tests result: SUCCESS ==

1 test OK.

Total duration: 3 sec 529 ms
Tests result: SUCCESS
root@8e92ba5c0e38:/# python -m test test_email
Run tests sequentially
0:00:00 load avg: 0.61 [1/1] test_email

== Tests result: SUCCESS ==

1 test OK.

Total duration: 3 sec 495 ms
Tests result: SUCCESS

root@8e92ba5c0e38:/# python -m test test_email_renamed
Run tests sequentially
0:00:00 load avg: 0.72 [1/1] test_email_renamed

== Tests result: SUCCESS ==

1 test OK.

Total duration: 85 ms
Tests result: SUCCESS

```