### PR TITLE
Make parseaddr and getaddresses return Unicode when given Unicode input

### DIFF
--- a/Lib/email/test/test_email.py
+++ b/Lib/email/test/test_email.py
@@ -2322,16 +2322,19 @@ class TestMiscellaneous(TestEmailBase):
 
     def test_parseaddr_unicode(self):
         """Test parseaddr with unicode strings"""
-
         test_cases = [
-            u'user@example.com',
-            u'Test User <user@example.com>',
-            u'"Test User" <user@example.com>',
+            (u'user@example.com', ('', u'user@example.com')),
+            (u'Test User <user@example.com>', (u'Test User', u'user@example.com')),
+            (u'"Test User" <user@example.com>', (u'Test User', u'user@example.com')),
         ]
         
-        for addr in test_cases:
+        for addr, expected in test_cases:
             result = Utils.parseaddr(addr, strict=True)
-            self.assertNotEqual(result, ('', ''))
+            self.assertEqual(result, expected)
+            if result[0]:
+                self.assertIsInstance(result[0], unicode)
+            if result[1]:
+                self.assertIsInstance(result[1], unicode)
             
             result_non_strict = Utils.parseaddr(addr, strict=False)
             self.assertEqual(result, result_non_strict)
@@ -2449,18 +2452,22 @@ Foo
         eq(addrs[0][1], 'foo@bar.com')
 
     def test_getaddresses_unicode(self):
-        """Test getaddresses with unicode strings in Python 2"""
-
+        """Test getaddresses with unicode strings"""
         test_cases = [
-            ([u'user@example.com'], [('', 'user@example.com')]),
-            ([u'Test User <user@example.com>'], [('Test User', 'user@example.com')]),
-            ([u'"Test User" <user@example.com>'], [('Test User', 'user@example.com')]),
-            ([u'user1@example.com', u'user2@example.com'], [('', 'user1@example.com'), ('', 'user2@example.com')]),
+            ([u'user@example.com'], [('', u'user@example.com')]),
+            ([u'Test User <user@example.com>'], [(u'Test User', u'user@example.com')]),
+            ([u'"Test User" <user@example.com>'], [(u'Test User', u'user@example.com')]),
+            ([u'user1@example.com', u'user2@example.com'], [('', u'user1@example.com'), ('', u'user2@example.com')]),
         ]
         
         for addrs, expected in test_cases:
             result = Utils.getaddresses(addrs)
             self.assertEqual(result, expected)
+            for realname, email in result:
+                if realname:
+                    self.assertIsInstance(realname, unicode)
+                if email:
+                    self.assertIsInstance(email, unicode)
 
     def test_make_msgid_collisions(self):
         # Test make_msgid uniqueness, even with multiple threads

--- a/Lib/email/test/test_email_renamed.py
+++ b/Lib/email/test/test_email_renamed.py
@@ -2201,16 +2201,19 @@ class TestMiscellaneous(TestEmailBase):
 
     def test_parseaddr_unicode(self):
         """Test parseaddr with unicode strings"""
-
         test_cases = [
-            u'user@example.com',
-            u'Test User <user@example.com>',
-            u'"Test User" <user@example.com>',
+            (u'user@example.com', ('', u'user@example.com')),
+            (u'Test User <user@example.com>', (u'Test User', u'user@example.com')),
+            (u'"Test User" <user@example.com>', (u'Test User', u'user@example.com')),
         ]
         
-        for addr in test_cases:
+        for addr, expected in test_cases:
             result = utils.parseaddr(addr, strict=True)
-            self.assertNotEqual(result, ('', ''))
+            self.assertEqual(result, expected)
+            if result[0]:
+                self.assertIsInstance(result[0], unicode)
+            if result[1]:
+                self.assertIsInstance(result[1], unicode)
             
             result_non_strict = utils.parseaddr(addr, strict=False)
             self.assertEqual(result, result_non_strict)
@@ -2310,18 +2313,22 @@ Foo
         eq(addrs[0][1], 'foo@bar.com')
 
     def test_getaddresses_unicode(self):
-        """Test getaddresses with unicode strings in Python 2"""
-
+        """Test getaddresses with unicode strings"""
         test_cases = [
-            ([u'user@example.com'], [('', 'user@example.com')]),
-            ([u'Test User <user@example.com>'], [('Test User', 'user@example.com')]),
-            ([u'"Test User" <user@example.com>'], [('Test User', 'user@example.com')]),
-            ([u'user1@example.com', u'user2@example.com'], [('', 'user1@example.com'), ('', 'user2@example.com')]),
+            ([u'user@example.com'], [('', u'user@example.com')]),
+            ([u'Test User <user@example.com>'], [(u'Test User', u'user@example.com')]),
+            ([u'"Test User" <user@example.com>'], [(u'Test User', u'user@example.com')]),
+            ([u'user1@example.com', u'user2@example.com'], [('', u'user1@example.com'), ('', u'user2@example.com')]),
         ]
         
         for addrs, expected in test_cases:
             result = utils.getaddresses(addrs)
             self.assertEqual(result, expected)
+            for realname, email in result:
+                if realname:
+                    self.assertIsInstance(realname, unicode)
+                if email:
+                    self.assertIsInstance(email, unicode)
 
     def test__quote_unquote(self):
         eq = self.assertEqual

--- a/Lib/email/utils.py
+++ b/Lib/email/utils.py
@@ -162,16 +162,19 @@ def getaddresses(fieldvalues, strict=True):
         a = _AddressList(all)
         return a.addresslist
 
+    unicode_flags = []
     converted_values = []
     for v in fieldvalues:
-        if isinstance(v, unicode):
+        is_unicode = isinstance(v, unicode)
+        unicode_flags.append(is_unicode)
+
+        if is_unicode:
             v = v.encode('utf-8')
         elif not isinstance(v, str):
             v = str(v)
         converted_values.append(v)
     
-    fieldvalues = converted_values
-    fieldvalues = _pre_parse_validation(fieldvalues)
+    fieldvalues = _pre_parse_validation(converted_values)
     addr = COMMASPACE.join(fieldvalues)
     a = _AddressList(addr)
     result = _post_parse_validation(a.addresslist)
@@ -188,7 +191,29 @@ def getaddresses(fieldvalues, strict=True):
     if len(result) != n:
         return [('', '')]
 
-    return result
+    final_result = []
+    result_idx = 0
+
+    for i, was_unicode in enumerate(unicode_flags):
+        if result_idx >= len(result):
+            break
+
+        realname, email = result[result_idx]
+
+        if was_unicode:
+            if realname:
+                realname = realname.decode('utf-8')
+            if email:
+                email = email.decode('utf-8')
+
+        final_result.append((realname, email))
+        result_idx += 1
+
+    while result_idx < len(result):
+        final_result.append(result[result_idx])
+        result_idx += 1
+
+    return final_result
 
 
 def _check_parenthesis(addr):
@@ -347,12 +372,12 @@ def parseaddr(addr, strict=True):
     if isinstance(addr, list):
         addr = addr[0]
 
-    # FIX: Support both str and unicode in Python 2
+    is_unicode = isinstance(addr, unicode)
+
     if not isinstance(addr, (str, unicode)):
         return ('', '')
 
-    # Convert unicode to str for consistent processing
-    if isinstance(addr, unicode):
+    if is_unicode:
         addr = addr.encode('utf-8')
 
     addr = _pre_parse_validation([addr])[0]
@@ -361,8 +386,17 @@ def parseaddr(addr, strict=True):
     if not addrs or len(addrs) > 1:
         return ('', '')
 
-    return addrs[0]
+    result = addrs[0]
 
+    if is_unicode:
+        realname, email = result
+        if realname:
+            realname = realname.decode('utf-8')
+        if email:
+            email = email.decode('utf-8')
+        return (realname, email)
+
+    return result
 
 
 # rfc822.unquote() doesn't properly de-backslash-ify in Python pre-2.3.


### PR DESCRIPTION
```
Python 2.7.18.13 (default, Mar 13 2026, 23:52:31) 
[GCC 11.2.1 20220127 (Red Hat 11.2.1-9)] on linux2
Binary build provided by ActiveState http://www.ActiveState.com.
Type "help", "copyright", "credits" or "license" for more information.
>>> from email.utils import getaddresses, parseaddr
>>> parseaddr('user1@example.com')
('', 'user1@example.com')
>>> parseaddr(u'user1@example.com')
('', u'user1@example.com')
>>> getaddresses(['user1@example.com', 'John Doe <user2@example.com>'])
[('', 'user1@example.com'), ('John Doe', 'user2@example.com')]
>>> getaddresses([u'user1@example.com', u'John Doe <user2@example.com>'])
[('', u'user1@example.com'), (u'John Doe', u'user2@example.com')]

```