### PR TITLE
CVE-2023-27043 Unicode follow-up: add parseaddr regression test (Python 3.7)

### DIFF
--- a/Lib/test/test_email/test_email.py
+++ b/Lib/test/test_email/test_email.py
@@ -3319,6 +3319,23 @@ Foo
         # Test email.utils.supports_strict_parsing attribute
         self.assertEqual(email.utils.supports_strict_parsing, True)
 
+    def test_parseaddr_unicode(self):
+        # CVE-2023-27043 Unicode regression guard. The 2.7 refactor had to
+        # accept both str and unicode at the parseaddr() boundary; in Python 3
+        # str is already Unicode, so this test just pins that strict-mode
+        # parsing still accepts valid non-ASCII input and agrees with the
+        # non-strict path.
+        for addr in (
+            'user@example.com',
+            'Test User <user@example.com>',
+            '"Test User" <user@example.com>',
+            '"Sürname, Firstname" <to@example.com>',
+        ):
+            with self.subTest(addr=addr):
+                strict = utils.parseaddr(addr, strict=True)
+                self.assertNotEqual(strict, ('', ''))
+                self.assertEqual(strict, utils.parseaddr(addr, strict=False))
+
     def test_getaddresses_nasty(self):
         for addresses, expected in (
             (['"Sürname, Firstname" <to@example.com>'],


### PR DESCRIPTION
## Summary
- Follow-up to the 2.7-branch Unicode refactor for CVE-2023-27043 (commit `c98f6b9d0f8`).
- The code portion of that refactor (`isinstance(addr, (str, unicode))` + `addr.encode('utf-8')`) is Python-2-only and would `NameError` on 3.x, so **no source change** to `Lib/email/utils.py` is required or applied here.
- Ports only the test intent: a direct `parseaddr(strict=True)` regression test covering ASCII and non-ASCII (`"Sürname, Firstname" <to@example.com>`), asserting (a) non-empty result and (b) strict-mode agrees with non-strict-mode — the same shape as the 2.7 test.

## Verification
Loaded the current `3.7.17.x` `Lib/email/utils.py` under a Python 3 interpreter (pure-Python module, safely isolated from stdlib) and ran the four test cases. All pass both assertions, confirming the existing CVE-2023-27043 fix on 3.7.17.x already handles Unicode correctly because Python 3 `str` is natively Unicode.

## Test plan
- [ ] `./python -m test test_email -k test_parseaddr_unicode` passes on Linux
- [ ] Full `test_email` suite still passes (no regressions in neighboring tests)
- [ ] Windows build: same test run

🤖 Generated with [Claude Code](https://claude.com/claude-code)