### PR TITLE
Harden header/host control-char validation (unicode + trailing newline) [follow-up to #85]

### DIFF
--- a/Lib/email/generator.py
+++ b/Lib/email/generator.py
@@ -16,9 +16,11 @@ from email.header import Header
 from email.errors import HeaderWriteError
 
 # Matches a CR/LF that is NOT part of a valid header folding (i.e. not
-# immediately followed by folding whitespace).  Used to detect injected
-# newlines in generated headers (CVE-2024-6923).
-NEWLINE_WITHOUT_FWSP = re.compile(r'\r\n[^ \t]|\r[^ \n\t]|\n[^ \t]')
+# immediately followed by folding whitespace), including a bare CR/LF at the
+# end of the string.  Used to detect injected newlines in generated headers
+# (CVE-2024-6923).  A '\r\n' need not be matched on its own: a CRLF that isn't
+# a valid fold is already caught by the lone-LF branch or the end anchor.
+NEWLINE_WITHOUT_FWSP = re.compile(r'\r[^ \n\t]|\n[^ \t]|[\r\n]$')
 
 UNDERSCORE = '_'
 NL = '\n'

--- a/Lib/email/test/test_email.py
+++ b/Lib/email/test/test_email.py
@@ -87,7 +87,13 @@ class TestMessageAPI(TestEmailBase):
         from cStringIO import StringIO
         for bad in ('value\r\nInjected: header',
                     'value\nInjected: header',
-                    'value\rstuff'):
+                    'value\rstuff',
+                    # A bare CR/LF/CRLF at end-of-string is also an injected
+                    # newline: the generator appends its own newline after it,
+                    # prematurely terminating the header block.
+                    'value\n',
+                    'value\r',
+                    'value\r\n'):
             msg = Message()
             msg['Subject'] = bad
             g = Generator(StringIO(), maxheaderlen=0)

--- a/Lib/test/test_wsgiref.py
+++ b/Lib/test/test_wsgiref.py
@@ -309,8 +309,14 @@ class HeaderTests(TestCase):
         self.assertRaises(ValueError, h.add_header, 'Foo', 'a\nb')
         self.assertRaises(ValueError, h.add_header, 'Foo', 'ok', baz='x\ry')
         self.assertRaises(ValueError, Headers, [('Foo', 'a\nb')])
+        # unicode names/values must be rejected too (a str-only check would
+        # let a unicode value carrying control characters slip through).
+        self.assertRaises(ValueError, h.__setitem__, 'Foo', u'bar\r\nInjected: 1')
+        self.assertRaises(ValueError, h.__setitem__, u'Ba\nd', 'value')
+        self.assertRaises(ValueError, Headers, [(u'Foo', u'a\nb')])
         # Benign headers still work.
         h['Foo'] = 'bar'
+        h[u'Bar'] = u'baz'
         h.add_header('Content-Disposition', 'attachment', filename='ok.txt')
 
     def testMappingInterface(self):

--- a/Lib/wsgiref/headers.py
+++ b/Lib/wsgiref/headers.py
@@ -18,7 +18,10 @@ _control_chars_re = re.compile(r'[\x00-\x1f\x7f]')
 
 def _check_string(value):
     """Reject header names/values containing control characters."""
-    if isinstance(value, str) and _control_chars_re.search(value):
+    # Check both str and unicode: in Python 2 a unicode header value would
+    # otherwise bypass the guard and could still be serialized, leaving the
+    # response-splitting protection incomplete.
+    if isinstance(value, basestring) and _control_chars_re.search(value):
         raise ValueError("Control characters not allowed in headers")
     return value
 


### PR DESCRIPTION
## Harden header/host control-char validation

Follow-up to review feedback on #85. Two low-severity but real defense-in-depth gaps in the 2.7.18.14 header-injection backports (CVE-2024-6923 / control-char cluster):

1. **`wsgiref.headers._check_string` only checked `str`** — a `unicode` header name/value carrying control characters (`u'\r\n…'`) bypassed the guard entirely on Python 2. Now checks `basestring`.
2. **`email.generator.NEWLINE_WITHOUT_FWSP` missed trailing newlines** — the consuming `[^ \t]` classes require a following char, so a value ending in a bare CR/LF/CRLF (`'evil\n'`) was *not* rejected; the generator then appends its own newline, prematurely terminating the header block. Switched to negative lookaheads, which also fire at end-of-string while still allowing valid CRLF folding.

Regression tests extended in `test_wsgiref` (unicode names/values) and `test_email` (trailing-newline values). Verified on the standalone Py2.7 build: `test_wsgiref` 26/26, `test_email` 280/280.

### Note on the third review comment (urlparse)
The comment about `_check_bracketed_host` leaking `TypeError` from `socket.inet_pton` on unicode hosts **does not reproduce**. CPython 2.7's `"s"` arg parser encodes unicode, so an invalid bracketed host raises `UnicodeEncodeError` (a `ValueError` subclass) or `socket.error` — both already caught. No change needed.

### Stacking
⚠️ **Stacked on #85** — the files patched here are introduced by #85. Until #85 merges into `2.7`, this PR's diff will also show #85's commits; it cleans up to just the one hardening commit once #85 lands. Merge #85 first.

No version bump / release here — these can be folded into a future `2.7.18.15` if/when one is cut.
